### PR TITLE
fix: 2022.3.1 release: coloring `get_cookie` can generate an cookie that overflows 8 bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,23 @@ All notable changes to the coloring NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-02-17
+***********************
+
+Fixed
+=====
+- ``get_cookie`` could overflow 8 bytes for certain dpid values
+- Made sure that the generated matched ``dl_src`` is a local unicast address
+
+General Information
+===================
+
+If you have been running this NApp version 2022.3.0 or prior in production it's recommended that you delete the previous flows before you start ``kytosd`` again since it this new version can end up pushing flows might not completely overwrite the old ones depending on dpids values:
+
+.. code:: bash
+
+  $ curl -X DELETE http://127.0.0.1:8181/api/kytos/flow_manager/v2/flows/ -H 'Content-type: application/json' -d '{ "flows": [ { "cookie": 12393906174523604992, "cookie_mask": 18374686479671623680 } ] }'
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "coloring",
   "description": "NApp to color a network topology",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": ["amlight/flow_stats", "kytos/flow_manager"],
   "license": "",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -181,6 +181,6 @@ class Main(KytosNApp):
 
     @staticmethod
     def get_cookie(dpid):
-        """Get cookie integer"""
-        return (int(dpid.replace(":", ""), 16)) + \
-               (settings.COOKIE_PREFIX << 56)
+        """Get 8-byte integer cookie."""
+        int_dpid = int(dpid.replace(":", ""), 16)
+        return (0x00FFFFFFFFFFFFFF & int_dpid) | (settings.COOKIE_PREFIX << 56)

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from flask import jsonify
 from kytos.core import KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.amlight.coloring import settings
+from napps.amlight.coloring.utils import make_unicast_local_mac
 from pyof.v0x04.common.port import PortNo
 
 
@@ -121,10 +122,10 @@ class Main(KytosNApp):
         :return: A representation of the color suitable for the given field
         """
         if field in ('dl_src', 'dl_dst'):
-            color_48bits = color & 0xffffffffffffffff
-            int_mac = struct.pack('!Q', color_48bits)[2:]
-            color_value = ':'.join([f'{b:02x}' for b in int_mac])
-            return color_value.replace('00', 'ee')
+            color_64bits = color & 0xffffffffffffffff
+            int_mac_6bytes = struct.pack('!Q', color_64bits)[2:]
+            color_value = ':'.join([f'{b:02x}' for b in int_mac_6bytes])
+            return make_unicast_local_mac(color_value.replace('00', 'ee'))
         if field in ('nw_src', 'nw_dst'):
             color_32bits = color & 0xffffffff
             int_ip = struct.pack('!L', color_32bits)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -218,3 +218,10 @@ class TestMain(TestCase):
         json_response = json.loads(response.data)
 
         self.assertEqual(json_response['colors'], {})
+
+    def test_get_cookie(self) -> None:
+        """test get_cookie."""
+        dpid = "cc4e244b11000000"
+        assert Main.get_cookie(dpid) == 0xac4e244b11000000
+        dpid = "0000000000000001"
+        assert Main.get_cookie(dpid) == 0xac00000000000001

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,18 @@
+"""Test utils.py."""
+import pytest
+
+
+from napps.amlight.coloring.utils import make_unicast_local_mac
+
+
+def test_make_unicast_local_mac_valid() -> None:
+    """test make_unicast_local_mac."""
+    mac = "31:94:06:ee:ee:ee"
+    assert make_unicast_local_mac(mac) == "3e:94:06:ee:ee:ee"
+
+
+@pytest.mark.parametrize("mac", ["31:94:06:ee:ee:eea", "a", ""])
+def test_make_unicast_local_mac_errors(mac) -> None:
+    """test make_unicast_local_mac."""
+    with pytest.raises(ValueError):
+        assert make_unicast_local_mac(mac)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,17 @@
+"""Utilities."""
+import re
+
+MAC_ADDR = re.compile("([0-9A-Fa-f]{2}[-:]){5}[0-9A-Fa-f]{2}$")
+
+
+def make_unicast_local_mac(mac: str) -> str:
+    """
+    The first two bits (b0, b1) of the most significant MAC address byte is for
+    its uniquiness and wether its locally administered or not. This functions
+    ensures it's a unicast (b0 -> 0) and locally administered (b1 -> 1).
+    """
+    if not re.search(MAC_ADDR, mac):
+        msg = "Invalid mac '{mac}': expected this regex format: {MAC_ADDR}"
+        raise ValueError(msg)
+    mac = mac.lower()
+    return mac[:1] + "e" + mac[2:]


### PR DESCRIPTION
Closes #37
Closes #38 

(It's related to https://github.com/kytos-ng/of_core/issues/102)

### Summary

See updated changelog file

### Local Tests

I used the same topology that @italovalcy has originally caught the issue and provisioned an EPL, the original issue no longer shows up and coloring flows are installed as expected:

```
kytos $> 2023-02-17 12:19:59,084 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:43682                                   
2023-02-17 12:19:59,085 - INFO [kytos.core.atcp_server] [atcp_server.py:131:connection_made] (MainThread) New connection from 127.0.0.1:43690
2023-02-17 12:19:59,596 - INFO [kytos.napps.kytos/of_core] [main.py:140:handle_features_reply] (thread_pool_sb_1) Connection ('127.0.0.1', 43682), Switch 00:24:38:94:06:00:00:00: OPENFLOW HANDSHAKE COMPLETE
2023-02-17 12:19:59,602 - INFO [kytos.napps.kytos/of_core] [main.py:140:handle_features_reply] (thread_pool_sb_1) Connection ('127.0.0.1', 43690), Switch cc:4e:24:4b:11:00:00:00: OPENFLOW HANDSHAKE COMPLETE
2023-02-17 12:19:59,628 - INFO [kytos.napps.kytos/flow_manager] [main.py:601:_send_flow_mods_from_request] (Thread-93) Send FlowMod from request dpid: 00:24:38:94:06:00:00:00, command: 
add, force: True, flows_dict: {'flows': [{'table_id': 0, 'match': {'dl_src': '2e:4b:11:ee:ee:ee'}, 'priority': 50000, 'actions': [{'action_type': 'output', 'port': 4294967293}], 'cookie': 12404101482092167168}], 'force': True}
2023-02-17 12:19:59,637 - INFO [kytos.napps.kytos/flow_manager] [main.py:601:_send_flow_mods_from_request] (Thread-95) Send FlowMod from request dpid: cc:4e:24:4b:11:00:00:00, command: 
add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321888485312036864, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2023-02-17 12:19:59,639 - INFO [kytos.napps.kytos/flow_manager] [main.py:601:_send_flow_mods_from_request] (Thread-94) Send FlowMod from request dpid: 00:24:38:94:06:00:00:00, command: add, force: False, flows_dict: {'flows': [{'priority': 1000, 'table_id': 0, 'cookie': 12321910788892655616, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2023-02-17 12:19:59,648 - INFO [kytos.napps.kytos/flow_manager] [main.py:601:_send_flow_mods_from_request] (Thread-96) Send FlowMod from request dpid: cc:4e:24:4b:11:00:00:00, command: add, force: True, flows_dict: {'flows': [{'table_id': 0, 'match': {'dl_src': '3e:94:06:ee:ee:ee'}, 'priority': 50000, 'actions': [{'action_type': 'output', 'port': 4294967293}], 'cookie': 12415901127533395968}], 'force': True}
2023-02-17 12:20:09,735 - INFO [kytos.napps.kytos/mef_eline] [main.py:646:handle_link_up] (thread_pool_app_5) Event handle_link_up Link(Interface('s1-eth53', 53, Switch('00:24:38:94:06:
00:00:00')), Interface('s3-eth52', 52, Switch('cc:4e:24:4b:11:00:00:00')))
kytos $>                                                                                                                                                                                 
```

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0xac24389406000000, duration=277.430s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=2e:4b:11:ee:ee:ee actions=CONTROLLER:65535
 cookie=0xaafa03c315386a4b, duration=29.990s, table=0, n_packets=4, n_bytes=296, send_flow_rem priority=20000,in_port="s1-eth53",dl_vlan=1 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaafa03c315386a4b, duration=30.017s, table=0, n_packets=4, n_bytes=280, send_flow_rem priority=10000,in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:4097->vlan_vid,output:"s1-eth53"
 cookie=0xab00389406000000, duration=277.425s, table=0, n_packets=100, n_bytes=4200, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```

I also ran `sdntrace` and `sdntrace_cp` requests, here's their responses:

```
{
    "result": [
        {
            "dpid": "00:24:38:94:06:00:00:00",
            "port": 1,
            "time": "2023-02-17 12:26:12.467668",
            "type": "starting",
            "vlan": 9
        },
        {
            "dpid": "cc:4e:24:4b:11:00:00:00",
            "out": {
                "port": 1,
                "vlan": 9
            },
            "port": 52,
            "time": "2023-02-17 12:26:12.467706",
            "type": "trace",
            "vlan": 1
        }
    ]
}
```

```
{
    "request": {
        "trace": {
            "eth": {
                "dl_vlan": 100
            },
            "switch": {
                "dpid": "00:24:38:94:06:00:00:00",
                "in_port": 1
            }
        }
    },
    "request_id": 30001,
    "result": [
        {
            "dpid": "00:24:38:94:06:00:00:00",
            "port": 1,
            "time": "2023-02-17 12:26:30.028629",
            "type": "starting"
        },
        {
            "msg": "none",
            "reason": "done",
            "time": "0:00:01.543398",
            "type": "last"
        }
    ],
    "start_time": "2023-02-17 12:26:30.028629",
    "total_time": "0:00:01.544058"
}
```



### End-to-End Tests

I'll dispatch e2e executions on AmLight's GitLab CI and post the result later. 