### PR TITLE
Changed how `table_group` updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,6 @@ All notable changes to the coloring NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
-General Information
-===================
-- ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
-
-[2022.3.1] - 2023-02-17
-***********************
-
 Changed
 =======
 - ``of_coloring`` now supports table group settings from ``of_multi_table``
@@ -21,6 +14,13 @@ Added
 =====
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/coloring.enable_table`` required to set a different ``table_id`` to flows.
 - Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now there is only ``'base'``.
+
+General Information
+===================
+- ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
+
+[2022.3.1] - 2023-02-17
+***********************
 
 Fixed
 =====

--- a/main.py
+++ b/main.py
@@ -88,7 +88,6 @@ class Main(KytosNApp):
                 for neighbor in switch_dict['neighbors']:
                     if neighbor not in switch_dict['flows']:
                         flow_dict = {
-                            'table_id': 0,
                             'match': {},
                             'priority': 50000,
                             'actions': [
@@ -214,7 +213,7 @@ class Main(KytosNApp):
                           f'coloring. Allowed table groups are '
                           f'{settings.TABLE_GROUP_ALLOWED}')
                 return
-        self.table_group = table_group
+        self.table_group.update(table_group)
         content = {"group_table": self.table_group}
         event_out = KytosEvent(name="kytos/coloring.enable_table",
                                content=content)


### PR DESCRIPTION
Closes #49 

### Summary

Updated how `self.table_group` updates so if less prone to uncaught errors
Fixed added changes in the wrong version.

### Local Tests

Manage `table_id` from `of_multi_table`
