### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the coloring NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.1.0] - 2023-06-12
+***********************
+
 Changed
 =======
 - ``of_coloring`` now supports table group settings from ``of_multi_table``
@@ -13,7 +16,7 @@ Changed
 Added
 =====
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/coloring.enable_table`` required to set a different ``table_id`` to flows.
-- Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now there is only ``'base'``.
+- Added ``settings.TABLE_GROUP_ALLOWED`` set containing the allowed table groups, for now there is only ``'base'``.
 
 General Information
 ===================

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Kytos-ng Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ To install this NApp, make sure to have the same venv activated as you have ``ky
 Requirements
 ============
 
-- `amlight/flow_stats <https://github.com/kytos-ng/flow_stats>`_
+- `kytos/topology <https://github.com/kytos-ng/topology>`_
 - `kytos/flow_manager <https://github.com/kytos-ng/flow_manager>`_
 
 Events

--- a/kytos.json
+++ b/kytos.json
@@ -3,9 +3,9 @@
   "username": "amlight",
   "name": "coloring",
   "description": "NApp to color a network topology",
-  "version": "2022.3.1",
-  "napp_dependencies": ["amlight/flow_stats", "kytos/flow_manager"],
-  "license": "",
+  "version": "2023.1.0",
+  "napp_dependencies": ["kytos/topology", "kytos/flow_manager"],
+  "license": "MIT",
   "tags": [],
   "url": ""
 }


### PR DESCRIPTION
Issue #52 needs to be merged first before merging this PR since its needed for `2023.1`

### Summary

- Bumped `2023.1.0` and updated changelog.
- I also updated the README.rst and added the missing MIT LICENSE

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
