### PR TITLE
Check for switch status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the coloring NApp will be documented in this file.
 Changed
 =======
 - ``of_coloring`` now supports table group settings from ``of_multi_table``
+- ``coloring`` now installs flows on the switches with ``UP`` status
 
 Added
 =====

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 
 import requests
 from kytos.core import KytosNApp, log, rest
+from kytos.core.common import EntityStatus
 from kytos.core.helpers import listen_to, alisten_to
 from kytos.core.rest_api import JSONResponse, Request
 from kytos.core.events import KytosEvent
@@ -84,6 +85,8 @@ class Main(KytosNApp):
                 if switch.ofp_version == '0x04':
                     controller_port = PortNo.OFPP_CONTROLLER
                 else:
+                    continue
+                if switch.status != EntityStatus.UP:
                     continue
                 for neighbor in switch_dict['neighbors']:
                     if neighbor not in switch_dict['flows']:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from kytos.lib.helpers import get_controller_mock, get_test_client
 
+from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
 from napps.amlight.coloring.main import Main
 
@@ -111,10 +112,12 @@ class TestMain:
         """Test method update_colors."""
         switch1 = Mock()
         switch1.dpid = '00:00:00:00:00:00:00:01'
+        switch1.status = EntityStatus.UP
         switch1.ofp_version = '0x04'
         switch2 = Mock()
         switch2.dpid = '00:00:00:00:00:00:00:02'
         switch2.ofp_version = '0x04'
+        switch2.status = EntityStatus.UP
 
         self.napp.controller.switches = {'1': switch1, '2': switch2}
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -112,12 +112,10 @@ class TestMain:
         """Test method update_colors."""
         switch1 = Mock()
         switch1.dpid = '00:00:00:00:00:00:00:01'
-        switch1.status = EntityStatus.UP
         switch1.ofp_version = '0x04'
         switch2 = Mock()
         switch2.dpid = '00:00:00:00:00:00:00:02'
         switch2.ofp_version = '0x04'
-        switch2.status = EntityStatus.UP
 
         self.napp.controller.switches = {'1': switch1, '2': switch2}
 
@@ -142,12 +140,26 @@ class TestMain:
         ]
 
         assert not self.napp.switches
+
+        # Verify no flows with switches DOWN
+        switch1.status = EntityStatus.DOWN
+        switch2.status = EntityStatus.DOWN
+
         self.napp.update_colors(links)
 
-        # Verify installed flows with colors
         assert len(self.napp.switches) == 2
         dpid1 = '00:00:00:00:00:00:00:01'
         dpid2 = '00:00:00:00:00:00:00:02'
+        sw1 = self.napp.switches[dpid1]
+        sw2 = self.napp.switches[dpid2]
+
+        assert sw1['flows'] == {}
+        assert sw2['flows'] == {}
+
+        # Verify installed flows with colors
+        switch1.status = EntityStatus.UP
+        switch2.status = EntityStatus.UP
+        self.napp.update_colors(links)
         sw1 = self.napp.switches[dpid1]
         sw2 = self.napp.switches[dpid2]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,coverage,lint
+envlist = coverage,lint
 
 
 [testenv]


### PR DESCRIPTION
Closes #52 

### Summary

Checking if the switch is `UP` to give time to listen first for `enable_table` event

### Local Tests
Changed pipeline status to `enabling` through MongoDB while kytos is shut down. Coloring installs its flows in the proper table id.

### End-to-End Tests
Tests results:
```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 28%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 31%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 49%]
...                                                                      [ 50%]
tests/test_e2e_14_mef_eline.py x                                         [ 51%]
tests/test_e2e_15_mef_eline.py ..                                        [ 52%]
tests/test_e2e_20_flow_manager.py .....................                  [ 61%]
tests/test_e2e_21_flow_manager.py ...                                    [ 62%]
tests/test_e2e_22_flow_manager.py ...............                        [ 68%]
tests/test_e2e_23_flow_manager.py ..............                         [ 75%]
tests/test_e2e_30_of_lldp.py ....                                        [ 76%]
tests/test_e2e_31_of_lldp.py ...                                         [ 78%]
tests/test_e2e_32_of_lldp.py ...                                         [ 79%]
tests/test_e2e_40_sdntrace.py ...........                                [ 84%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 87%]
tests/test_e2e_50_maintenance.py ........................                [ 97%]
tests/test_e2e_60_of_multi_table.py .....                                [100%]
```
