### PR TITLE
Added listener for switch and link deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to the coloring NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Subscribed to new event ``kytos/topology.link.disabled``, which triggers the deletion of neighbors and flows from each endpoint of the deleted link.
+- Subscribed to event ``kytos/topology.switch.disabled``, which deletes a disabled switch data on ``switches`` dictionary.
+
+Changed
+=======
+- ``coloring`` now deletes resources when a link or switch has been disabled.
+- ``coloring`` now does not recognize switches and links that are not enabled,
+
 [2023.1.0] - 2023-06-12
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Subscribed
 
 - ``kytos/topology.updated``
 - ``kytos/of_multi_table.enable_table``
+- ``kytos/topology.switch.disabled``
+- ``kytos/topology.link.disabled``
 
 Published
 ---------

--- a/main.py
+++ b/main.py
@@ -44,6 +44,13 @@ class Main(KytosNApp):
     def execute(self):
         """ Topology updates are executed through events. """
 
+    @listen_to('kytos/topology.switch.deleted')
+    def on_switch_deleted(self, event):
+        """Remove switch from dictionary"""
+        with self._switches_lock:
+            switch = event.content['switch']
+            self.switches.pop(switch.dpid, None)
+
     @listen_to('kytos/topology.updated')
     def topology_updated(self, event):
         """Update colors on topology update."""

--- a/main.py
+++ b/main.py
@@ -72,6 +72,8 @@ class Main(KytosNApp):
         with self._switches_lock:
             for switch in self.controller.switches.copy().values():
                 if not switch.is_enabled():
+                    if switch.dpid in self.switches:
+                        self.switches[switch.dpid]['neighbors'] = set()
                     continue
                 if switch.dpid not in self.switches:
                     color = int(switch.dpid.replace(':', '')[4:], 16)

--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ class Main(KytosNApp):
 
         if switch_b_id == switch_a_id:
             return
-        
+
         with self._switches_lock:
             flow_mods = defaultdict(list)
             flow = self.switches[switch_a_id]['flows'][switch_b_id]
@@ -154,8 +154,19 @@ class Main(KytosNApp):
     def handle_switch_disabled(self, dpid):
         """Handle switch deletion. Links are expected to be disabled first
          therefore the deleted inner dictionary is expected to be empty with
-          no flows and neighbors."""
+         no flows and neighbors."""
         with self._switches_lock:
+            try:
+                sw_dct = self.switches[dpid]
+                if sw_dct['flows'] or sw_dct['neighbors']:
+                    log.error(f"There was an error cleanning up {dpid}. "
+                              "The fields 'flows' and 'neighbors' should be"
+                              " empty.")
+                    return
+            except KeyError as err:
+                log.error(f"Error while handling disabled switch: "
+                          f"Switch {err} not found.")
+                return
             self.switches.pop(dpid, None)
 
     def shutdown(self):


### PR DESCRIPTION
Closes #58 

### Summary

Added listener `'kytos/topology.*.deleted'` to delete switches and links from coloring.

### Local Tests
Deleted links and switches. Verifies that `self.switches` was updated and flows were deleted.

### End-To-End Test
```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ......FFFF.........                        [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ..F.                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ........                                 [100%]
```
The failures are fixed in PR [#277](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/277)
