### PR TITLE
release: bumped 2023.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the coloring NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.0] - 2024-02-16
+***********************
+
 Added
 =====
 - Subscribed to new event ``kytos/topology.link.disabled``, which triggers the deletion of neighbors and flows from each endpoint of the deleted link.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "coloring",
   "description": "NApp to color a network topology",
-  "version": "2023.1.0",
+  "version": "2023.2.0",
   "napp_dependencies": ["kytos/topology", "kytos/flow_manager"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A nightly e2e tests are passing
